### PR TITLE
fix: (hacky) prevent previewing on unconnectable remotes

### DIFF
--- a/consult-jump-project.el
+++ b/consult-jump-project.el
@@ -106,7 +106,7 @@ The returned list contains:
    #recent files
    time (seconds) elapsed since last modification of recent project files)."
   (if (and (file-remote-p root) (fboundp 'tramp-connectable-p)
-	   (not (let ((non-essential t)) (tramp-connectable-p root))))
+	   (not (tramp-connectable-p root)))
       ;; Only access remote roots if already connected.
       (list root nil nil nil)
     (let* ((proj-path (expand-file-name root))

--- a/consult-jump-project.el
+++ b/consult-jump-project.el
@@ -188,6 +188,45 @@ files.  Save details."
 						      :background ,vc-annotate-background))))
 		"")))))
 
+(defun consult-jump-project--multi-state (sources)
+  "Avoid previewing unconnected remote buffers from SOURCES.
+This is basically a copy of `consult--multi-state'."
+  (when-let (states (delq nil (mapcar (lambda (src)
+                                        (when-let (fun (plist-get src :state))
+                                          (cons src (funcall fun))))
+                                      sources)))
+    (let (last-fun)
+      (pcase-lambda (action `(,cand . ,src))
+        (pcase action
+          ('setup
+           (pcase-dolist (`(,_ . ,fun) states)
+             (funcall fun 'setup nil)))
+          ('exit
+           (pcase-dolist (`(,_ . ,fun) states)
+             (funcall fun 'exit nil)))
+          ('preview
+           (let ((selected-fun (cdr (assq src states))))
+             ;; If the candidate source changed during preview communicate to
+             ;; the last source, that none of its candidates is previewed anymore.
+             (when (and last-fun (not (eq last-fun selected-fun)))
+               (funcall last-fun 'preview nil))
+             (setq last-fun selected-fun)
+             ;; this additional tramp-connectable-p check is the only difference between this and consult--multi-state
+             (when (and selected-fun (or (get-buffer cand)
+                                         (not (file-remote-p cand))
+                                         (and (fboundp 'tramp-connectable-p)
+                                              (let ((non-essential t)) (tramp-connectable-p cand)))))
+               (funcall selected-fun 'preview cand))))
+          ('return
+           (let ((selected-fun (cdr (assq src states))))
+             ;; Finish all the sources, except the selected one.
+             (pcase-dolist (`(,_ . ,fun) states)
+               (unless (eq fun selected-fun)
+                 (funcall fun 'return nil)))
+             ;; Finish the source with the selected candidate
+             (when selected-fun
+               (funcall selected-fun 'return cand)))))))))
+
 ;;;###autoload
 (defun consult-jump-project (&optional arg)
   "Jump between projects, project files, and project buffers with consult.
@@ -196,12 +235,26 @@ always-present list of projects with age and buffer/file count.
 Call with a prefix argument ARG to disable display of project
 files and buffers, and display only (other) projects."
   (interactive "P")
-  (let ((consult-jump-project--original-buffer (current-buffer)))
-    (consult-buffer
-     `(,@(unless arg (remove 'consult--source-project-root
-			     consult-project-buffer-sources))
-       (:name ,(concat (if (consult--project-root) "Other ") "Projects")
-	      ,@consult-jump-project--projects)))))
+  ;; this is copied from consult-buffer but with our custom :state function passed in
+  (let* ((consult-jump-project--original-buffer (current-buffer))
+         (sources `(,@(unless arg (remove 'consult--source-project-root
+			                  consult-project-buffer-sources))
+                    (:name ,(concat (if (consult--project-root) "Other ") "Projects")
+	                   ,@consult-jump-project--projects))))
+    (let ((selected (consult--multi (or sources consult-buffer-sources)
+                                    :require-match
+                                    (confirm-nonexistent-file-or-buffer)
+                                    :prompt "Switch to: "
+                                    :history 'consult--buffer-history
+                                    :sort nil
+                                    :state (consult-jump-project--multi-state sources)
+                                    )))
+      ;; For non-matching candidates, fall back to buffer creation.
+      (unless (plist-get (cdr selected) :match)
+        (consult--buffer-action (car selected))))
+    )
+  )
+
 
 (provide 'consult-jump-project)
 

--- a/consult-jump-project.el
+++ b/consult-jump-project.el
@@ -196,7 +196,8 @@ always-present list of projects with age and buffer/file count.
 Call with a prefix argument ARG to disable display of project
 files and buffers, and display only (other) projects."
   (interactive "P")
-  (let ((consult-jump-project--original-buffer (current-buffer)))
+  (let ((consult-jump-project--original-buffer (current-buffer))
+        (non-essential t))
     (consult-buffer
      `(,@(unless arg (remove 'consult--source-project-root
 			     consult-project-buffer-sources))


### PR DESCRIPTION
Following up from our last conversation https://github.com/jdtsmith/consult-jump-project/pull/4 I managed to find a very hacky way to prevent previewing on unconnectable remotes via monkey patching the `consult--multi-state` and `consult-buffer` functions

Honestly, this might not be worth it at this point, I doubt many others are going to have this problem so feel free to reject this, and I'll just maintain this on my separate fork for my own purposes.

The alternative is to maybe upstream some changes to consult itself to add the same checks to here https://github.com/minad/consult/blob/c74ae6149172e3429b844c22d67e02b01abea1e4/consult.el#L1446 but as we discovered earlier, tramp hooks into many things and there may be more

I think creating the preview also causes some other downstream issues like for instance, calling `project-buffers` will error out because there'll be a connection created for the unconnectable remote, and then when we try to expand-file-name on the buffers in buffer-list we hit an error